### PR TITLE
Update runQueries.sh

### DIFF
--- a/bin/runQueries.sh
+++ b/bin/runQueries.sh
@@ -67,7 +67,10 @@ do
         
     if ${COLLECT_PERFDATA};
         then
+            curdir=${CURRENT_DIR}
+            cd ${CURRENT_DIR}/perfdatascripts/
             ${CURRENT_DIR}/perfdatascripts/collectPerfData.sh ${RUN_ID} ${RESULTS_DIR} ${PERFDATA_OUTPUTDIR} >> ${RUN_LOG_FILE}
+            cd $curdir
         fi
         
 done


### PR DESCRIPTION
collectPerData.sh script assumes it is being executed from it's own local directory. You will get a error on running ../globalConfig.sh otherwise. This could also be changed by configuring collectPerfData.sh to use ./globalConfig.sh instead of ../globalConfig.sh however I do not know if there are other dependencies.

https://github.com/hdinsight/HivePerformanceAutomation/compare/master...SeanMikha:patch-2#diff-f23facf3e65829686d6c9d6fbd325107